### PR TITLE
Fix vids order

### DIFF
--- a/demo/src/assets/js/app.js
+++ b/demo/src/assets/js/app.js
@@ -17,9 +17,10 @@ let options = {
   color: '#6c77f7',
   fullscreenToggle:  '#js-vp-fstoggle',
   fullscreenToggleKeyCode: 'Digit1',
-  playlistTmpl: playlistTmpl
+  itemTmpl: playlistTmpl
 }
 
 // Init on #js-player
-const vids = new VimeoPlaylist('js-vp-player', options).init()
+const vids = new VimeoPlaylist('js-vp-player', options)
+vids.init()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vimeoplaylist",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vimeoplaylist",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@vimeo/player": "^2.16.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimeoplaylist",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Create endless video playlists with the Vimeo Player API, with ",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -114,7 +114,7 @@ import playlistTmpl from './plist.tmpl'
 // Plugin Options
 let options = {
   hasPlaylist: true,
-  playlistTmpl: playlistTmpl,
+  itemTmpl: playlistTmpl,
   playlist: [
     { "id": "288588748" },
     { "id": "328536852" },
@@ -145,7 +145,9 @@ The options param supports the following properties:
 | `playlistNavPrev`         | `String / Element ID`             | id of Prev nav element                                   | `#js-vp-prev`     |
 | `playlistNavNext`         | `String / Element ID`             | id of Next element                                       | `#js-vp-next`     |
 | `playlist`                | `Array of Objects`                | playlist as array of objects { "id" : <vimeoid> }        | `[]`              |
-| `playlistTemplate`        | `HTML Template Literal`           | Template for playlist Items                              | Template found at plist.tmpl.js             |
+| `itemTmpl`                | `HTML Template Literal`           | Template for playlist Items                              | Template found at plist.tmpl.js               |
+| `itemName`                | `String`                          | Parent name of playlist Items (becomes parent class name) | `plist-item`              |
+| `itemTrigger`             | `String / Element selector`       | Wrapping Link selector (trigger) of playlist items (matching playlistTemplate)      | `plist-item__link`              |
 | `supportsKeyNav`          | `Boolean`                         | Enables next/prev key nav                                | `true`            |  
 | `width`                   | `Number`                          | Video width in px                                        | `900`             |
 | `title`                   | `Boolean`                         | Show video title                                         | `false`           |
@@ -314,11 +316,10 @@ let options = {
 
 ### Playlist Item Template
 
-The Playlist Items provide video and user info (ie: id, title, thubnails, url, duration, etc). 
+Each item in the playlist provides video and user info (ie: id, title, thubnails, url, duration, etc). 
 
-You can use the default template or provide your own template to customize the layout/markup of each playlist item. Simply create a template literal, perhaps as a seperate file, and pass its reference to the `itemTemplate` option.
+You can use the default template or provide your own to customize the layout/markup of each playlist item. Simply create a template literal, perhaps as a seperate file, and pass its reference to the `itemTmpl` option.
 
-Note: when a playlist item is playing, it will have an `is-playing` class to leverage.
 
 #### Playlist Template Example
 ```
@@ -344,7 +345,6 @@ export default function playlistTmpl(data) {
   `
 }
 ```
-
 ### Pass Playlist template 
 
 ```
@@ -352,7 +352,7 @@ import playlistTmpl from './plist.tmpl'
 
 let options = {
   hasPlaylist: true,
-  playlistTmpl: playlistTmpl,
+  itemTmpl: playlistTmpl,
   ...
 }
 ```
@@ -387,6 +387,21 @@ Your template's data param can use to following properties from Vimeo's reponse 
 | user_url                 | `(string\|link)`   | User url                               |
 | width                    | `number`          | Video width in px                      |
 
+
+#### Playlist Template Requirements 
+
+It's important that your playlist template at least have a wrapping trigger/link element as seen in the above example. 
+
+**Important:** 
+
+The `itemTrigger` option defines the playlist Item wrapping link/trigger used for click events. If you're passing your own `itemTmpl`, make sure to update the `itemTrigger` to match your link's selector name. Will refactor out this requirement in the future. 
+
+The `itemName` option is used to define the parent class name of the playlist item block. You might also want to make sure that has some relevance to how you organize item's class names.
+
+**Additional Notes**: 
+
+When a playlist item is playing, it will have an `is-playing` class to leverage. 
+When a playlist item is paused, it will have an `is-paused` class.
 
 ### Playlist Navigation
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,6 +16,22 @@ export function fetchData(url) {
 }
 
 /**
+ * Fetch all vimeo vids with Promise.all
+ * @param {Array} playlist - Array of objects that make upd 
+ * @returns {Promise} - Combined promises from api requestsn
+ */
+export function fetchAllVids(playlist) {
+  return Promise.all(playlist.map(request => {
+    return fetch('https://vimeo.com/api/v2/video/' + request.id + '.json')
+      .then(response => {
+        return response.json();
+      })
+      .catch((ex) => console.log('failed', ex))
+  }))
+}
+
+
+/**
  * Error check for Fetch
  * @param {Object} res - fetch response
  * @returns 

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,13 +20,14 @@ export function fetchData(url) {
  * @param {Array} playlist - Array of objects that make upd 
  * @returns {Promise} - Combined promises from api requestsn
  */
-export function fetchAllVids(playlist) {
+export function fetchAllVimeoVids(playlist) {
   return Promise.all(playlist.map(request => {
-    return fetch('https://vimeo.com/api/v2/video/' + request.id + '.json')
-      .then(response => {
-        return response.json();
-      })
-      .catch((ex) => console.log('failed', ex))
+    return fetch(`https://vimeo.com/api/v2/video/${request.id}.json`)
+    .then((res)=>{ 
+      if (res.ok) return res.json(); 
+      else throw new Error("Status code error :" + res.status) 
+    })
+      .catch(err=>console.log(err))
   }))
 }
 

--- a/src/vimeo-playlist.js
+++ b/src/vimeo-playlist.js
@@ -2,7 +2,7 @@
 'use strict'
 
 import Player from '@vimeo/player'
-import { fetchData, createFrag, hasEl } from './utils'
+import { createFrag, hasEl, fetchAllVids } from './utils'
 import playlistTmpl from './plist.tmpl'
 
 /**
@@ -24,7 +24,9 @@ import playlistTmpl from './plist.tmpl'
   playlistNavPrev: '#js-vp-prev',
   supportsKeyNav: true,
   playlist: [],
-  playlistTmpl: playlistTmpl
+  itemTmpl: playlistTmpl,
+  itemName: 'plist-item',
+  itemTrigger: '.plist-item__link'
 }
 
 /**
@@ -101,6 +103,7 @@ VimeoPlaylist.prototype = {
     if (!this.player) return
     this.settings()
     this.listeners()
+    //if (this.hasPlaylist) this.buildPlaylist()
     if (this.hasPlaylist) this.buildPlaylist()
   },
 
@@ -203,41 +206,38 @@ VimeoPlaylist.prototype = {
   },
 
   /**
-   * Build Playlist
-   * Constructs playlist markup from this.playlist
-   * Fetches playlist info from Vimeo API
-   * @external { fetchData | createFrag }
+   * Build Playlist from fetched vimeo vids
+   * Fetches vids in a promise.all, builds markup in a frag, adds to dom.
+   * @external { fetchAllVids | createFrag }
    * @fires { setupFirstVid | handlePlaylistClicks}
    */
   buildPlaylist() {
     let counter = 0
-
-    this.playlist.forEach((plist) => {
-      let id = plist.id
-      let vidInfo = fetchData('https://vimeo.com/api/v2/video/' + id + '.json')
-      // if (!vidInfo) return
-      vidInfo.then((obj) => {
+    const fetchedVids = fetchAllVids(this.playlist);
+    
+    fetchedVids.then((vids) => {
+      vids.forEach((vid) => {
+        let tmpl = this.itemTmpl(vid[0]);
+        let frag = createFrag(tmpl, 'article', this.itemName)
         counter++
-        let tmpl = this.playlistTmpl(obj[0])
-        //let tmpl = plistItemTemplate(obj[0])
-        let frag = createFrag(tmpl, 'article', 'plist-item')
 
         if (this.playlistOutput) {
           this.playlistOutput.appendChild(frag)
         } else {
           console.warn('VimeoPlaylist: Provide a valid playlist id')
         }
-
+        
         if (counter === this.vidCount) {
           this.setupFirstVid()
           // define this.playlistItems
           if (!this.hasPlaylist) return
-          this.playlistItems = document.querySelectorAll('.plist-item__link')
+          this.playlistItems = document.querySelectorAll(this.itemTrigger)
           this.handlePlaylistClicks()
         }
-      })
-    })
+      });
+    });
   },
+
 
   /**
    * setupFirstVid

--- a/src/vimeo-playlist.js
+++ b/src/vimeo-playlist.js
@@ -2,7 +2,7 @@
 'use strict'
 
 import Player from '@vimeo/player'
-import { createFrag, hasEl, fetchAllVids } from './utils'
+import { createFrag, hasEl, fetchAllVimeoVids } from './utils'
 import playlistTmpl from './plist.tmpl'
 
 /**
@@ -207,16 +207,18 @@ VimeoPlaylist.prototype = {
 
   /**
    * Build Playlist from fetched vimeo vids
-   * Fetches vids in a promise.all, builds markup in a frag, adds to dom.
+   * Fetches vids inConstructs playlist markup from this.playlist by
+   * 
    * @external { fetchAllVids | createFrag }
    * @fires { setupFirstVid | handlePlaylistClicks}
    */
   buildPlaylist() {
     let counter = 0
-    const fetchedVids = fetchAllVids(this.playlist);
-    
+    const fetchedVids = fetchAllVimeoVids(this.playlist);
+
     fetchedVids.then((vids) => {
       vids.forEach((vid) => {
+        if (vid == undefined) return;
         let tmpl = this.itemTmpl(vid[0]);
         let frag = createFrag(tmpl, 'article', this.itemName)
         counter++
@@ -224,7 +226,7 @@ VimeoPlaylist.prototype = {
         if (this.playlistOutput) {
           this.playlistOutput.appendChild(frag)
         } else {
-          console.warn('VimeoPlaylist: Provide a valid playlist id')
+          console.warn('VimeoPlaylist: Provide a valid selector to output playlist')
         }
         
         if (counter === this.vidCount) {


### PR DESCRIPTION
Fixes issues with order of playlist not consistent with data. 
- Fetch requests are wrapped in a promise.all
- Guard check is added to swallow up request 404s by checking for undefined.
- Renamed a few options:
  - `playlistTmpl` renamed to `itemTmpl` (all `playlistItem` options will be just `item`)
- Added 2 new options for playlist items - itemName and itemTrigger. See readme for purpose. Should maybe rethink this a bit though.
