### PR TITLE
Refact fullscreen

### DIFF
--- a/demo/src/assets/js/app.js
+++ b/demo/src/assets/js/app.js
@@ -16,7 +16,7 @@ let options = {
   playlistOutput: '#js-vp-playlist',
   color: '#6c77f7',
   fullscreenToggle: '#js-vp-fstoggle',
-  fullscreenToggleKeyCode: 'Digit1',
+  fullscreenToggleKeyCode: 'KeyF',
   itemTmpl: playlistTmpl
 }
 

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -28,6 +28,7 @@
     <section class="player">
       <div class="player__grid">
         <div class="player__flex">
+          <iframe id="testing-fullscreen"></iframe>
           <div id="js-vp-player" class="player__vid"></div>
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vimeoplaylist",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vimeoplaylist",
-      "version": "2.1.3",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@vimeo/player": "^2.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimeoplaylist",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Create endless video playlists with the Vimeo Player API, with ",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -155,10 +155,9 @@ The options param supports the following properties:
 | `muted`                   | `Boolean`                         | Mute vids                                                                      | `false`                         |
 | `controls`                | `Boolean`                         | Show player controls                                                           | `true`                          |
 | `autoplay`                | `Boolean`                         | Autoplay vids (required for continuous playlist vids)                          | `true`                          |
-| `fullScreenToggle`        | `Boolean`                         | Clicking `Enter` triggers fullscreen vid                                       | `false`                         |
 | `color`                   | `String (3 or 6 digit hex value)` | Player ui color                                                                | `#7B8EF9`                       |
 | `fullscreenToggle`        | `String / Element ID`             | id of fullscreen video toggle control                                          | `#js-vp-fstoggle`               |
-| `fullscreenToggleKeyCode` | `String / Element ID`             | full screen toggle keycode                                                     | `Digit1`                        |
+| `fullscreenToggleKeyCode` | `String / Element ID`             | full screen toggle keycode, ie: `KeyF` for `F` key                             | `null`                          |
 | `debug`                   | `Boolean`                         | Outputs helpful logs                                                           | `false`                         |
 
 <br/>

--- a/src/vimeo-playlist.js
+++ b/src/vimeo-playlist.js
@@ -17,7 +17,7 @@ VimeoPlaylist.defaults = {
   autoplay: true,
   color: '#7B8EF9',
   fullscreenToggle: '#js-vp-fstoggle',
-  fullscreenToggleKeyCode: 'Digit1',
+  fullscreenToggleKeyCode: null,
   hasPlaylist: true,
   playlistOutput: '#js-vp-playlist',
   playlistNavNext: '#js-vp-next',
@@ -378,7 +378,7 @@ VimeoPlaylist.prototype = {
    * Targeted vimeo iframe for full screen vid on Enter
    */
   toggleFullscreen() {
-    let vid = document.querySelector('iframe')
+    let vid = this.player.element
     if (!document.vid) {
       vid.requestFullscreen()
     } else {


### PR DESCRIPTION
This PR fixes issues with full screen toggle as described in #29.

## Updates 

- The `toggleFullscreen` method now targets `this.player.element` instead of the page's first `iframe`. `this.player.element` references the Vimeo iframe instance.

- `fullscreenToggleKeyCode` now defaults to null instead of `Digit1`, which makes better sense. Demo includes `KeyF` for the `f` key, which seems like a good example.