### PR TITLE
Feat almost ended

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,23 +1,39 @@
 {
-  "parser": "babel-eslint",
   "extends": "eslint:recommended",
-  "globals": {
-    "console": true,
-    "Player": true,
-    "document": true,
-    "module": true,
-    "navigator": true,
-    "Promise": true,
-    "requestAnimationFrame": true,
-    "setTimeout": true,
-    "window": true,
-    "IntersectionObserver": true,
-    "DocumentTouch": true,
-    "CustomEvent": true,
-    "location": true,
-    "Element": true
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "impliedStrict": true
+    }
+  },
+  "env": {
+    "browser": true,
+    "es6": true
   },
   "rules": {
-    "no-unused-vars": "warn"
+    "eqeqeq": ["error", "always"],
+    "no-console": "off",
+    "no-undefined": "off",
+    "indent": ["error", 2],
+    "quotes": ["warn", "single"],
+    "no-multi-spaces": [
+      "warn",
+      {
+        "exceptions": {
+          "VariableDeclarator": true
+        }
+      }
+    ],
+    "no-trailing-spaces": "warn",
+    "new-cap": "warn",
+    "no-redeclare": [
+      "error",
+      {
+        "builtinGlobals": true
+      }
+    ],
+    "no-var": 1,
+    "semi": [0, "always"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vimeoplaylist",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vimeoplaylist",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "@vimeo/player": "^2.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vimeoplaylist",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vimeoplaylist",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@vimeo/player": "^2.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimeoplaylist",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Vimeo Playlists: A JS library to create endless video playlists with the Vimeo Player API. Features playlist UI, controls and customizable template.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimeoplaylist",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Vimeo Playlists: A JS library to create endless video playlists with the Vimeo Player API. Features playlist UI, controls and customizable template.",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -452,13 +452,25 @@ let options = {
 
 <br/>
 
+### Using Almost Ended (Timeupdate)
+
+The Vimeo Player API _seems_ to have an issue where End Screen overlays the video if the player is scrolled out of view (not visible).
+
+We can _seemingly_ address this by listening until the current video is _almost_ ended, then calling next.
+This prevents the End Screen from appearing, which _seems_ desireable for a continous playlist.
+
+So, as of `v2.6.0`, we use `Timeupdate` instead of `ended` to call `next()` when current vid is `0.5s` from end.
+
+<br/>
+
 ## 📅 ToDos
 
 - ~~Option for custom playlist template~~
 - ~~Document availble data options from Vimeo's reponse object for playlist template.~~
 - ~~Make hybrid npm module to support `import` and `require`~~.
-- Refactor how video id's are fetched, providing better error handling for 404'd items.
+- ~~Provide a util method for ellapsed time.~~
+- ~~Address issue with End Screen overlaying player/video.~~
+- Provide better error handling for 404'd items.
 - Since autoplay on load only works if muted due to Chrome policy, provide a button to unmute.
-- Provide a util method for ellapsed time.
 - Provide destory method
 - Perhaps support for multiple instances per page, with everything scoped to element.

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import VimeoPlaylist from './vimeo-playlist.js'
 import { formatTime } from './utils'
-// export default VimeoPlaylist
-// export {VimeoPlaylist, formatTime}
-module.exports = VimeoPlaylist; 
-module.exports.formatTime = formatTime;
+
+export { formatTime }
+export default VimeoPlaylist

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import fetch from 'isomorphic-fetch'
 
-'use strict'
+;('use strict')
 
 /**
  * Fetch Data utility
@@ -17,31 +17,32 @@ export function fetchData(url) {
 
 /**
  * Fetch all vimeo vids with Promise.all
- * @param {Array} playlist - Array of objects that make upd 
+ * @param {Array} playlist - Array of objects that make upd
  * @returns {Promise} - Combined promises from api requestsn
  */
 export function fetchAllVimeoVids(playlist) {
-  return Promise.all(playlist.map(request => {
-    return fetch(`https://vimeo.com/api/v2/video/${request.id}.json`)
-    .then((res)=>{ 
-      if (res.ok) return res.json(); 
-      else throw new Error("Status code error :" + res.status) 
+  return Promise.all(
+    playlist.map((request) => {
+      return fetch(`https://vimeo.com/api/v2/video/${request.id}.json`)
+        .then((res) => {
+          if (res.ok) return res.json()
+          else throw new Error('Status code error :' + res.status)
+        })
+        .catch((err) => console.log(err))
     })
-      .catch(err=>console.log(err))
-  }))
+  )
 }
-
 
 /**
  * Error check for Fetch
  * @param {Object} res - fetch response
- * @returns 
+ * @returns
  */
 function checkError(res) {
   if (!res.ok) {
-    throw Error(res.statusText);
+    throw Error(res.statusText)
   }
-  return res.json();
+  return res.json()
 }
 
 /**

--- a/src/vimeo-playlist.js
+++ b/src/vimeo-playlist.js
@@ -118,6 +118,7 @@ VimeoPlaylist.prototype = {
    * @fires {onEnd | onPause | onPlay | toggleFullscreen}
    */
   listeners() {
+    this.onAlmostEnd()
     this.onEnd()
     this.onPause()
     this.onPlay()
@@ -134,6 +135,7 @@ VimeoPlaylist.prototype = {
    * @param {string} id - vimeo video id
    */
   loadVid(id) {
+    console.log(id, this.player, this.player.loadVideo(id))
     this.player
       .loadVideo(id)
       .then(() => {
@@ -148,12 +150,29 @@ VimeoPlaylist.prototype = {
   /**
    * OnEnd
    * Listens for when a vid ends.
-   * @fires {next}
+   * @fires next()
    */
   onEnd() {
     this.player.on('ended', () => {
       if (this.debug) console.debug('ended')
       this.next()
+    })
+  },
+
+  /**
+   * OnTimeupdate
+   * Listens for when almost ends, based on threshold
+   * @fires next()
+   */
+  onAlmostEnd() {
+    this.player.on('timeupdate', (data) => {
+      const currentTime = data.seconds
+      const duration = data.duration
+      const threshold = 0.5
+      if (duration - currentTime <= threshold) {
+        if (this.debug) console.log('Video is almost ended')
+        this.next()
+      }
     })
   },
 
@@ -185,7 +204,7 @@ VimeoPlaylist.prototype = {
    * @fires {toggleFullscreen} - if fullscreenToggle
    */
   onFullScreenToggle() {
-    //FS Toggle ke
+    //FS Toggle key
     if (this.fullscreenToggleKeyCode) {
       window.addEventListener(
         'keydown',
@@ -218,7 +237,7 @@ VimeoPlaylist.prototype = {
 
     fetchedVids.then((vids) => {
       vids.forEach((vid) => {
-        if (vid == undefined) return
+        if (vid === undefined) return
         let tmpl = this.itemTmpl(vid[0])
         let frag = createFrag(tmpl, 'article', this.itemName)
         counter++
@@ -304,8 +323,8 @@ VimeoPlaylist.prototype = {
     document.addEventListener(
       'keydown',
       (event) => {
-        if (event.code == 'ArrowRight') this.next()
-        if (event.code == 'ArrowLeft') this.prev()
+        if (event.code === 'ArrowRight') this.next()
+        if (event.code === 'ArrowLeft') this.prev()
       },
       false
     )


### PR DESCRIPTION
# Using Almost Ended for `next()`

The Vimeo Player API _seems_ to have an issue where End Screen overlays the video if the player is scrolled out of view (not visible).

We can _seemingly_ address this by listening until the current video is _almost_ ended, then calling next.
This prevents the End Screen from appearing, which _seems_ desireable for a continous playlist.

So, as of `v2.4.0`, we use `Timeupdate` instead of `ended` to call `next()` when current vid is `0.5s` from end.
